### PR TITLE
Update CIDR ranges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,11 +138,11 @@ aks-cluster/
 ### Network Configuration
 
 The cluster uses the following network architecture:
-- **VNet CIDR**: 10.248.27.0/24
-- **System Subnet**: 10.248.27.0/26
-- **Spark Subnet**: 10.248.27.64/26
-- **Private Endpoints**: 10.248.27.128/27
-- **Service CIDR**: 10.250.0.0/16
+- **VNet CIDR**: 10.0.0.1/24
+- **System Subnet**: 10.0.0.2/24
+- **Spark Subnet**: 10.248.27.64/24
+- **Private Endpoints**: 10.248.27.128/24
+- **Service CIDR**: 10.0.0.0/16
 
 ### Spark Optimization
 


### PR DESCRIPTION
## Summary
- update network addresses under **Network Configuration**

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68524b7d07088332b940656aab5065d9

## Summary by Sourcery

Update README network configuration to reflect new CIDR ranges for VNet, subnets, private endpoints, and service CIDR

Documentation:
- Update VNet CIDR to 10.0.0.1/24 in README under Network Configuration
- Update System Subnet CIDR to 10.0.0.2/24 in README
- Update Spark Subnet CIDR to 10.248.27.64/24 in README
- Update Private Endpoints CIDR to 10.248.27.128/24 in README
- Update Service CIDR to 10.0.0.0/16 in README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated network configuration details in the README to reflect new CIDR blocks and subnet sizes for VNet, subnets, and service CIDR.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->