### PR TITLE
Fix host encryption property

### DIFF
--- a/modules/aks/main.tf
+++ b/modules/aks/main.tf
@@ -110,7 +110,8 @@ resource "azurerm_kubernetes_cluster_node_pool" "additional" {
   os_disk_type    = each.value.os_disk_type
   os_disk_size_gb = each.value.os_disk_size_gb
 
-  ultra_ssd_enabled = each.value.ultra_ssd_enabled
+  ultra_ssd_enabled       = each.value.ultra_ssd_enabled
+  host_encryption_enabled = each.value.enable_host_encryption
 
   node_labels = each.value.node_labels
 

--- a/test/integration/monitoring_test.go
+++ b/test/integration/monitoring_test.go
@@ -69,7 +69,7 @@ func validateLogAnalyticsWorkspace(t *testing.T, ctx context.Context, cred *azid
 	assert.NotNil(t, workspace)
 
 	// Validate workspace properties
-	assert.Equal(t, armoperationalinsights.WorkspaceSkuNameEnumPerGB2018, *workspace.Properties.SKU.Name)
+	assert.Equal(t, armoperationalinsights.WorkspaceSKUNameEnumPerGB2018, *workspace.Properties.SKU.Name)
 	assert.Equal(t, int32(30), *workspace.Properties.RetentionInDays)
 	assert.Equal(t, armoperationalinsights.PublicNetworkAccessTypeEnabled, *workspace.Properties.PublicNetworkAccessForIngestion)
 }
@@ -82,7 +82,7 @@ func validateContainerInsights(t *testing.T, ctx context.Context, cred *azidenti
 
 	// List diagnostic settings for the AKS cluster
 	pager := diagnosticClient.NewListPager(clusterID, nil)
-	
+
 	hasContainerInsights := false
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
@@ -91,7 +91,7 @@ func validateContainerInsights(t *testing.T, ctx context.Context, cred *azidenti
 			t.Logf("Warning: Could not retrieve diagnostic settings: %v", err)
 			return
 		}
-		
+
 		if page.Value != nil && len(page.Value) > 0 {
 			hasContainerInsights = true
 			break

--- a/test/integration/network_security_test.go
+++ b/test/integration/network_security_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v5"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -99,12 +100,12 @@ func validateNetworkSecurityGroup(t *testing.T, ctx context.Context, cred *azide
 
 	// List NSGs in resource group
 	pager := nsgClient.NewListPager(resourceGroupName, nil)
-	
+
 	var nsg *armnetwork.SecurityGroup
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		require.NoError(t, err)
-		
+
 		if len(page.Value) > 0 {
 			nsg = page.Value[0]
 			break
@@ -121,7 +122,7 @@ func validateNetworkSecurityGroup(t *testing.T, ctx context.Context, cred *azide
 	// Check for specific rules
 	hasHTTPSRule := false
 	hasDenyAllRule := false
-	
+
 	for _, rule := range rules {
 		if *rule.Properties.DestinationPortRange == "443" && *rule.Properties.Access == armnetwork.SecurityRuleAccessAllow {
 			hasHTTPSRule = true
@@ -218,7 +219,7 @@ func TestPrivateDNSZone(t *testing.T) {
 	subscriptionID := strings.Split(privateDNSZoneID, "/")[2]
 
 	// Create Private DNS Zone client
-	dnsClient, err := armnetwork.NewPrivateZonesClient(subscriptionID, cred, nil)
+	dnsClient, err := armprivatedns.NewPrivateZonesClient(subscriptionID, cred, nil)
 	require.NoError(t, err)
 
 	// Get DNS zone name from ID
@@ -228,7 +229,7 @@ func TestPrivateDNSZone(t *testing.T) {
 	dnsZone, err := dnsClient.Get(ctx, resourceGroupName, dnsZoneName, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, dnsZone)
-	
+
 	// Validate the zone name contains the expected pattern
 	assert.Contains(t, *dnsZone.Name, "privatelink")
 	assert.Contains(t, *dnsZone.Name, "azmk8s.io")


### PR DESCRIPTION
## Summary
- support enabling host encryption for node pools
- correct constant and import typos in integration tests

## Testing
- `terraform validate` in `modules/aks`
- `go vet ./...` in `test`
- `go test ./unit/...` *(fails: required Terraform providers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68524763408c8332b19f8f6ca5cbe0e5