### PR TITLE
Update AGENTS guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,13 +11,16 @@ These instructions apply to the entire repository.
 
 ## Linting
 - After initializing Terraform (`terraform init`), run `terraform validate` for Terraform code changes.
+- Always execute `terraform plan` to ensure the configuration produces a valid plan. Saving the plan output with `terraform plan -out=plan.out` is recommended.
 - For Go code, run `golangci-lint run` or `go vet ./...` when available.
 
 ## Testing
 - Unit tests are located in `test/unit`. Run `go test ./test/unit/...`.
 - Integration tests in `test/integration` require Azure credentials and may incur cost. Run them only when necessary with `RUN_INTEGRATION_TESTS=true go test ./test/integration/...`.
+- When files under the `test/` directory change, execute `go test ./...` and ensure `golangci-lint run` and `go fmt ./...` pass.
 
 ## Workflow
 - **Code changes** (Terraform or Go) require running the format, lint, and test steps above before committing.
+- For Terraform changes, include `terraform plan` as part of the workflow to verify the execution plan.
 - **Documentation or comment-only changes** may skip tests and linting.
 


### PR DESCRIPTION
## Summary
- update `AGENTS.md` with a terraform plan requirement
- clarify when to run Go tests and linters
- note terraform plan in the workflow

## Testing
- No tests run since this updates only documentation

------
https://chatgpt.com/codex/tasks/task_e_68545d1b7c948332ba6ec5bbf30c3da0

## Summary by Sourcery

Enhance agent contribution guidelines with Terraform planning and test/linting clarifications

Documentation:
- Add requirement to run `terraform plan` and recommend saving the plan output
- Clarify that Go tests, linters, and formatting must be run when files in `test/` change
- Include `terraform plan` step in the CI workflow for Terraform changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated instructions to require running and saving a Terraform plan after initialization and validation.
  - Added guidance to run tests and code linting when making changes in the test directory.
  - Enhanced workflow steps to explicitly include Terraform plan verification before committing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->