### PR TITLE
feat: Add Spot Instance support to AKS module

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ This repository contains Terraform configuration for deploying a production-grad
 
 ### Node Pools
 - **System Pool**: Dedicated for Kubernetes system components (1-5 nodes)
-- **Spark Pool**: Isolated pool for Apache Spark workloads (4-10 nodes)
-- **Node Taints**: Ensures Spark workloads run on dedicated nodes
+- **Spark Pool**: Isolated pool for Apache Spark workloads (4-10 nodes), with support for both regular and Spot instances.
+- **Node Taints**: Ensures Spark workloads run on dedicated nodes, including appropriate taints for Spot instance node pools.
 
 ### Security & Networking
 - **Hub-Spoke Architecture**: Enterprise network topology with ExpressRoute support
@@ -197,9 +197,9 @@ The cluster includes comprehensive monitoring:
 
 ### Cost Optimization Tips
 
-1. **Reserved Instances**: Save up to 72% with 1 or 3-year reservations
-2. **Spot Instances**: Use for non-critical Spark workloads (up to 90% savings)
-3. **Auto-scaling**: Configure based on actual workload patterns
+1. **Reserved Instances**: Save up to 72% with 1 or 3-year reservations for regular node pools.
+2. **Spot Instances**: Now supported directly within the module for applicable node pools (e.g., Spark workers). Use for non-critical, interruptible Spark workloads (up to 90% savings). Configure `priority = "Spot"` in the node pool definition.
+3. **Auto-scaling**: Configure based on actual workload patterns for all node pool types.
 4. **Right-sizing**: Monitor usage and adjust VM sizes accordingly
 5. **Log Retention**: Reduce retention period if 30 days is excessive
 

--- a/modules/aks/main.tf
+++ b/modules/aks/main.tf
@@ -119,5 +119,10 @@ resource "azurerm_kubernetes_cluster_node_pool" "additional" {
     for taint in coalesce(each.value.node_taints, []) : "${taint.key}=${taint.value}:${taint.effect}"
   ]
 
+  priority        = each.value.priority
+  eviction_policy = each.value.priority == "Spot" ? each.value.eviction_policy : null
+  spot_max_price  = each.value.priority == "Spot" ? each.value.spot_max_price : null
+
+
   tags = merge(var.tags, each.value.tags)
 }

--- a/modules/aks/variables.tf
+++ b/modules/aks/variables.tf
@@ -82,6 +82,10 @@ variable "node_pools" {
       effect = string
     }))
     tags = map(string)
+    # Spot instance configuration
+    priority        = optional(string, "Regular") # Spot or Regular
+    eviction_policy = optional(string, "Delete")  # Delete or Deallocate
+    spot_max_price  = optional(number, -1)        # Max price for Spot instances, -1 for on-demand price
   }))
   default = {}
 }


### PR DESCRIPTION
This commit introduces the capability to create AKS node pools using Spot Instances for cost optimization.

Changes include:
- Modified the `aks` module to accept Spot Instance parameters (priority, eviction_policy, spot_max_price) for node pools.
- Updated the `aks` module README with documentation for the new feature and an example.
- Updated the `examples/spark-cluster` to demonstrate a Spark worker node pool configured with Spot Instances.
- Updated the main README to highlight Spot Instance support in Features and Cost Optimization sections.
- Ran linters and formatters.

## Summary by Sourcery

Add Spot Instance support to AKS module, exposing new parameters for Spot node pools and updating documentation and examples to demonstrate usage

New Features:
- Enable Spot Instance support for AKS node pools via new priority, eviction_policy, and spot_max_price parameters

Documentation:
- Extend module README with Spot Instance node pool parameters and object structure
- Add Spot Instance node pool examples in the spark-cluster sample
- Update root README to showcase Spot support in features and cost optimization sections

Chores:
- Run linters and formatters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring Azure Spot instance node pools, including options for priority, eviction policy, and maximum spot price.
  - Introduced an example Spark worker node pool using Spot instances with autoscaling capabilities.

- **Documentation**
  - Updated documentation to clarify Spot instance support, configuration options, and cost optimization tips.
  - Added detailed descriptions and examples for new Spot-related node pool attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->