### PR TITLE
Fix Kubernetes service CIDR overlap with VNet address spaces

### DIFF
--- a/ACCESS_GUIDE.md
+++ b/ACCESS_GUIDE.md
@@ -132,10 +132,10 @@ spec:
 ## Network Connectivity Summary
 
 - **Cluster API Endpoint**: Private only (10.x.x.x range)
-- **Service CIDR**: 10.0.0.0/16
-- **DNS Service IP**: 10.0.0.10
-- **System Nodes**: 10.0.1.0/24
-- **Spark Nodes**: 10.0.2.0/25
+- **Service CIDR**: 172.16.0.0/16
+- **DNS Service IP**: 172.16.0.10
+- **System Nodes**: Environment-specific (10.0.1.0/26 - 10.0.4.0/26)
+- **Spark Nodes**: Environment-specific (10.0.1.64/26 - 10.0.4.64/26)
 
 ## Security Considerations
 

--- a/DEPLOYMENT_CHECKLIST.md
+++ b/DEPLOYMENT_CHECKLIST.md
@@ -18,8 +18,8 @@
   - System: x.x.x.0/26 (64 IPs)
   - Spark: x.x.x.64/26 (64 IPs)
   - Endpoints: x.x.x.128/25 (128 IPs)
-- ✅ **Service CIDR**: 10.0.0.0/16
-- ✅ **DNS Service IP**: 10.0.0.10
+- ✅ **Service CIDR**: 172.16.0.0/16
+- ✅ **DNS Service IP**: 172.16.0.10
 
 ### Node Pools
 - ✅ **System Pool**:

--- a/EXPRESSROUTE_SETUP.md
+++ b/EXPRESSROUTE_SETUP.md
@@ -21,7 +21,7 @@ On-Premises/AWS ←→ ExpressRoute ←→ Hub VNet (10.0.5.0/23) ←→ AKS Spo
   - Staging: 10.0.3.0/24 (system: 10.0.3.0/26, spark: 10.0.3.64/26, endpoints: 10.0.3.128/26)
   - Prod: 10.0.4.0/24 (system: 10.0.4.0/26, spark: 10.0.4.64/26, endpoints: 10.0.4.128/26)
 - **Hub VNet**: 10.0.5.0/23 (existing)
-- **Service CIDR**: 10.0.0.0/16 (Kubernetes services)
+- **Service CIDR**: 172.16.0.0/16 (Kubernetes services - non-overlapping range)
 
 ### 2. VNet Peering
 - Bidirectional peering between hub and spoke

--- a/PRODUCTION_READINESS.md
+++ b/PRODUCTION_READINESS.md
@@ -99,7 +99,8 @@ run_command_enabled = false  # Disable for production
    - Ensure on-premises DNS can resolve Azure private zones
 
 3. **IP Address Management**
-   - Verify no IP conflicts with 10.0.0.0/24
+   - Verify no IP conflicts with VNet ranges (10.0.1.0/24 - 10.0.4.0/24) and hub network
+   - Confirm service CIDR (172.16.0.0/16) does not overlap with any connected networks
    - Document IP allocation for future growth
 
 ## 📋 Pre-deployment Checklist

--- a/README.md
+++ b/README.md
@@ -137,12 +137,12 @@ aks-cluster/
 
 ### Network Configuration
 
-The cluster uses the following network architecture:
-- **VNet CIDR**: 10.0.0.0/24
-- **System Subnet**: 10.0.1.0/26
-- **Spark Subnet**: 10.0.2.0/25
-- **Private Endpoints**: 10.0.3.0/25
-- **Service CIDR**: 10.0.0.0/16
+The cluster uses the following network architecture (environment-specific):
+- **VNet CIDR**: Environment-specific (10.0.1.0/24 - 10.0.4.0/24)
+- **System Subnet**: x.x.x.0/26 (64 IPs)
+- **Spark Subnet**: x.x.x.64/26 (64 IPs)
+- **Private Endpoints**: x.x.x.128/25 (128 IPs)
+- **Service CIDR**: 172.16.0.0/16
 
 ### Spark Optimization
 

--- a/envs/dev/locals.tf
+++ b/envs/dev/locals.tf
@@ -10,6 +10,11 @@ locals {
   system_vm_size = "Standard_D2s_v3" # 2 vCPU, 8 GB RAM - for system pods
   spark_vm_size  = "Standard_D4s_v3" # 4 vCPU, 16 GB RAM - for Spark testing
 
+  # Kubernetes service network configuration
+  # Uses non-overlapping RFC1918 range to avoid conflicts with VNet and hub network
+  service_cidr   = "172.16.0.0/16"
+  dns_service_ip = "172.16.0.10"
+
   subnets = {
     system = {
       name             = "subnet-aks-system"

--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -280,8 +280,8 @@ module "aks" {
   network_profile = {
     network_plugin = "azure"
     network_policy = "azure"
-    dns_service_ip = "10.0.0.10"
-    service_cidr   = "10.0.0.0/16"
+    dns_service_ip = "172.16.0.10"
+    service_cidr   = "172.16.0.0/16"
     outbound_type  = "loadBalancer"
     load_balancer_profile = {
       managed_outbound_ip_count = 2

--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -280,8 +280,8 @@ module "aks" {
   network_profile = {
     network_plugin = "azure"
     network_policy = "azure"
-    dns_service_ip = "172.16.0.10"
-    service_cidr   = "172.16.0.0/16"
+    dns_service_ip = local.dns_service_ip
+    service_cidr   = local.service_cidr
     outbound_type  = "loadBalancer"
     load_balancer_profile = {
       managed_outbound_ip_count = 2

--- a/envs/prod/locals.tf
+++ b/envs/prod/locals.tf
@@ -10,6 +10,11 @@ locals {
   system_vm_size = "Standard_D8s_v3" # 8 vCPU, 32 GB RAM - for system pods
   spark_vm_size  = "Standard_D8s_v3" # 8 vCPU, 32 GB RAM - general purpose for Spark
 
+  # Kubernetes service network configuration
+  # Uses non-overlapping RFC1918 range to avoid conflicts with VNet and hub network
+  service_cidr   = "172.16.0.0/16"
+  dns_service_ip = "172.16.0.10"
+
   subnets = {
     system = {
       name             = "subnet-aks-system"

--- a/envs/prod/main.tf
+++ b/envs/prod/main.tf
@@ -280,8 +280,8 @@ module "aks" {
   network_profile = {
     network_plugin = "azure"
     network_policy = "azure"
-    dns_service_ip = "10.0.0.10"
-    service_cidr   = "10.0.0.0/16"
+    dns_service_ip = "172.16.0.10"
+    service_cidr   = "172.16.0.0/16"
     outbound_type  = "loadBalancer"
     load_balancer_profile = {
       managed_outbound_ip_count = 2

--- a/envs/prod/main.tf
+++ b/envs/prod/main.tf
@@ -280,8 +280,8 @@ module "aks" {
   network_profile = {
     network_plugin = "azure"
     network_policy = "azure"
-    dns_service_ip = "172.16.0.10"
-    service_cidr   = "172.16.0.0/16"
+    dns_service_ip = local.dns_service_ip
+    service_cidr   = local.service_cidr
     outbound_type  = "loadBalancer"
     load_balancer_profile = {
       managed_outbound_ip_count = 2

--- a/envs/qa/locals.tf
+++ b/envs/qa/locals.tf
@@ -10,6 +10,11 @@ locals {
   system_vm_size = "Standard_D2s_v3" # 2 vCPU, 8 GB RAM - for system pods
   spark_vm_size  = "Standard_D4s_v3" # 4 vCPU, 16 GB RAM - for Spark testing
 
+  # Kubernetes service network configuration
+  # Uses non-overlapping RFC1918 range to avoid conflicts with VNet and hub network
+  service_cidr   = "172.16.0.0/16"
+  dns_service_ip = "172.16.0.10"
+
   subnets = {
     system = {
       name             = "subnet-aks-system"

--- a/envs/qa/main.tf
+++ b/envs/qa/main.tf
@@ -280,8 +280,8 @@ module "aks" {
   network_profile = {
     network_plugin = "azure"
     network_policy = "azure"
-    dns_service_ip = "10.0.0.10"
-    service_cidr   = "10.0.0.0/16"
+    dns_service_ip = "172.16.0.10"
+    service_cidr   = "172.16.0.0/16"
     outbound_type  = "loadBalancer"
     load_balancer_profile = {
       managed_outbound_ip_count = 2

--- a/envs/qa/main.tf
+++ b/envs/qa/main.tf
@@ -280,8 +280,8 @@ module "aks" {
   network_profile = {
     network_plugin = "azure"
     network_policy = "azure"
-    dns_service_ip = "172.16.0.10"
-    service_cidr   = "172.16.0.0/16"
+    dns_service_ip = local.dns_service_ip
+    service_cidr   = local.service_cidr
     outbound_type  = "loadBalancer"
     load_balancer_profile = {
       managed_outbound_ip_count = 2

--- a/envs/staging/locals.tf
+++ b/envs/staging/locals.tf
@@ -10,6 +10,11 @@ locals {
   system_vm_size = "Standard_D4s_v3" # 4 vCPU, 16 GB RAM - for system pods
   spark_vm_size  = "Standard_D8s_v3" # 8 vCPU, 32 GB RAM - for Spark staging
 
+  # Kubernetes service network configuration
+  # Uses non-overlapping RFC1918 range to avoid conflicts with VNet and hub network
+  service_cidr   = "172.16.0.0/16"
+  dns_service_ip = "172.16.0.10"
+
   subnets = {
     system = {
       name             = "subnet-aks-system"

--- a/envs/staging/main.tf
+++ b/envs/staging/main.tf
@@ -280,8 +280,8 @@ module "aks" {
   network_profile = {
     network_plugin = "azure"
     network_policy = "azure"
-    dns_service_ip = "10.0.0.10"
-    service_cidr   = "10.0.0.0/16"
+    dns_service_ip = "172.16.0.10"
+    service_cidr   = "172.16.0.0/16"
     outbound_type  = "loadBalancer"
     load_balancer_profile = {
       managed_outbound_ip_count = 2

--- a/envs/staging/main.tf
+++ b/envs/staging/main.tf
@@ -280,8 +280,8 @@ module "aks" {
   network_profile = {
     network_plugin = "azure"
     network_policy = "azure"
-    dns_service_ip = "172.16.0.10"
-    service_cidr   = "172.16.0.0/16"
+    dns_service_ip = local.dns_service_ip
+    service_cidr   = local.service_cidr
     outbound_type  = "loadBalancer"
     load_balancer_profile = {
       managed_outbound_ip_count = 2

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -54,8 +54,8 @@ module "aks" {
   network_profile = {
     network_plugin = "azure"
     network_policy = "azure"
-    dns_service_ip = "10.0.0.10"
-    service_cidr   = "10.0.0.0/16"
+    dns_service_ip = "172.16.0.10"
+    service_cidr   = "172.16.0.0/16"
     outbound_type  = "loadBalancer"
   }
 

--- a/examples/spark-cluster/main.tf
+++ b/examples/spark-cluster/main.tf
@@ -175,8 +175,8 @@ module "aks_spark" {
   network_profile = {
     network_plugin = "azure"
     network_policy = "azure"
-    dns_service_ip = "10.0.0.10"
-    service_cidr   = "10.0.0.0/16"
+    dns_service_ip = "172.16.0.10"
+    service_cidr   = "172.16.0.0/16"
     outbound_type  = "loadBalancer"
     load_balancer_profile = {
       managed_outbound_ip_count = 4 # More IPs for high throughput

--- a/modules/aks/README.md
+++ b/modules/aks/README.md
@@ -48,8 +48,8 @@ module "aks" {
   network_profile = {
     network_plugin = "azure"
     network_policy = "azure"
-    dns_service_ip = "10.0.0.10"
-    service_cidr   = "10.0.0.0/16"
+    dns_service_ip = "172.16.0.10"
+    service_cidr   = "172.16.0.0/16"
     outbound_type  = "loadBalancer"
   }
   
@@ -163,8 +163,8 @@ module "aks" {
   network_profile = {
     network_plugin = "azure"
     network_policy = "azure"
-    dns_service_ip = "10.0.0.10"
-    service_cidr   = "10.0.0.0/16"
+    dns_service_ip = "172.16.0.10"
+    service_cidr   = "172.16.0.0/16"
     outbound_type  = "loadBalancer"
     load_balancer_profile = {
       managed_outbound_ip_count = 2


### PR DESCRIPTION
This commit fixes a critical networking bug where the Kubernetes service CIDR (10.0.0.0/16) was overlapping with VNet address spaces across all environments, which could cause:
- IP address conflicts between K8s services and Azure VNet resources
- Routing issues and unpredictable traffic patterns
- Service connectivity problems
- DNS resolution failures

Changes:
- Updated service_cidr from 10.0.0.0/16 to 172.16.0.0/16 (non-overlapping)
- Updated dns_service_ip from 10.0.0.10 to 172.16.0.10 (within new service CIDR)

Affected environments:
- dev (VNet: 10.0.1.0/24)
- qa (VNet: 10.0.2.0/24)
- staging (VNet: 10.0.3.0/24)
- prod (VNet: 10.0.4.0/24)

The new service CIDR (172.16.0.0/16) is a valid RFC1918 private range that does not conflict with any existing VNet ranges or the hub network (10.0.0.0/16).

## Summary by Sourcery

Prevent IP conflicts by updating the Kubernetes service CIDR and DNS service IP to a non-overlapping private range across all environments.

Bug Fixes:
- Change service_cidr from 10.0.0.0/16 to 172.16.0.0/16 to avoid overlap with existing VNets
- Update dns_service_ip from 10.0.0.10 to 172.16.0.10 within the new service CIDR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated cluster network addressing across environments: service CIDR and DNS service IP moved to the new 172.16.x.y range and applied consistently in examples and environment configs.

* **Documentation**
  * Updated docs, checklists, and examples to reflect the new service CIDR, DNS service IP, and environment-specific subnet descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->